### PR TITLE
Fix closing-channels example - removed buffer

### DIFF
--- a/examples/closing-channels/closing-channels.go
+++ b/examples/closing-channels/closing-channels.go
@@ -11,7 +11,7 @@ import "fmt"
 // to a worker goroutine. When we have no more jobs for
 // the worker we'll `close` the `jobs` channel.
 func main() {
-    jobs := make(chan int, 5)
+    jobs := make(chan int)
     done := make(chan bool)
 
     // Here's the worker goroutine. It repeatedly receives


### PR DESCRIPTION
Fixed closing channel example to match the desired output.
Using a buffered jobs channel would produce the following output:

`sent job 1`
`sent job 2`
`sent job 3`
`sent all jobs`
`received job 1`
`received job 2`
`received job 3`
`received all jobs`